### PR TITLE
add: option to include combined document url for get submission

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -196,8 +196,8 @@ export class DocusealApi {
     return this.http.get<GetSubmissionsResponse>("/submissions", query);
   }
 
-  async getSubmission(id: number): Promise<GetSubmissionResponse> {
-    return this.http.get<GetSubmissionResponse>(`/submissions/${id}`);
+  async getSubmission(id: number, include_combined_document_url = false): Promise<GetSubmissionResponse> {
+    return this.http.get<GetSubmissionResponse>(`/submissions/${id}${include_combined_document_url ? "?include=combined_document_url" : ""}`);
   }
 
   async createSubmission(

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -30,7 +30,7 @@ export declare class DocusealApi {
     archiveTemplate(id: number): Promise<ArchiveTemplateResponse>;
     permanentlyDeleteTemplate(id: number): Promise<ArchiveTemplateResponse>;
     listSubmissions(query?: GetSubmissionsQuery): Promise<GetSubmissionsResponse>;
-    getSubmission(id: number): Promise<GetSubmissionResponse>;
+    getSubmission(id: number, include_combined_document_url?: boolean): Promise<GetSubmissionResponse>;
     createSubmission(data: CreateSubmissionData): Promise<CreateSubmissionResponse>;
     createSubmissionFromEmails(data: CreateSubmissionsFromEmailsData): Promise<CreateSubmissionsFromEmailsResponse>;
     archiveSubmission(id: number): Promise<ArchiveSubmissionResponse>;


### PR DESCRIPTION
As discussed [here](https://github.com/docusealco/docuseal/discussions/297#discussioncomment-10238623), the query parameter `?include=combined_document_url` can be used to ensure a `combined_document_url` is returned (as long as the document has been completed). Without it, it is null until someone manually triggers the creation (e.g. by downloading the combined PDF).

For embedded services, this flag may be required and cannot be used with the current API. In this PR I merely added it as a flag for the specific GET submissions function. This could also be implemented more generalized by e.g. allowing additional function parameters for supplying arbitrary query parameters.